### PR TITLE
move <iostream> and add getloss() method for class ColorCorrection Model

### DIFF
--- a/modules/mcc/include/opencv2/mcc.hpp
+++ b/modules/mcc/include/opencv2/mcc.hpp
@@ -32,7 +32,7 @@
 
 #include "mcc/checker_detector.hpp"
 #include "mcc/checker_model.hpp"
-
+#include "mcc/ccm.hpp"
 
 /** @defgroup mcc Macbeth Chart module
 

--- a/modules/mcc/include/opencv2/mcc/ccm.hpp
+++ b/modules/mcc/include/opencv2/mcc/ccm.hpp
@@ -471,6 +471,7 @@ public:
     CV_WRAP void run();
 
     CV_WRAP Mat getCCM() const;
+    CV_WRAP double getLoss() const;
 
     /** @brief Infer using fitting ccm.
         @param img the input image.

--- a/modules/mcc/samples/color_correction_model.cpp
+++ b/modules/mcc/samples/color_correction_model.cpp
@@ -78,6 +78,10 @@ int main(int argc, char *argv[])
         //compte color correction matrix
         //! [get_ccm_Matrix]
         ColorCorrectionModel model1(src, Vinyl);
+        model1.run();
+        Mat ccm = model1.getCCM();
+        std::cout<<"ccm "<<ccm<<std::endl;
+        double loss = model1.getLoss();
         //! [get_ccm_Matrix]
          /* brief More models with different parameters, try it & check the document for details.
         */

--- a/modules/mcc/src/ccm.cpp
+++ b/modules/mcc/src/ccm.cpp
@@ -272,8 +272,6 @@ void ColorCorrectionModel::Impl::fitting(void)
     double res = solver->minimize(reshapeccm);
     ccm = reshapeccm.reshape(0, shape/3);
     loss = pow((res / masked_len), 0.5);
-    std::cout << " ccm " << ccm << std::endl;
-    std::cout << " loss " << loss << std::endl;
 }
 
 Mat ColorCorrectionModel::infer(const Mat& img, bool islinear)
@@ -390,6 +388,8 @@ void  ColorCorrectionModel::run(){
 Mat ColorCorrectionModel::getCCM() const{
     return p->ccm;
 }
-
+double ColorCorrectionModel::getLoss() const{
+    return p->loss;
+}
 } // namespace ccm
 } // namespace cv

--- a/modules/mcc/src/io.hpp
+++ b/modules/mcc/src/io.hpp
@@ -32,7 +32,6 @@
 
 #include <opencv2/core.hpp>
 #include <map>
-#include <iostream>
 
 namespace cv
 {


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under OpenCV (BSD) License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
